### PR TITLE
Use unused instead of deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -198,13 +198,12 @@ linters:
   enable:
     ## enabled by default
     #
-    - unused # Finds unused code
+    - unused # Checks Go code for unused constants, variables, functions and types
     - gosimple # Linter for Go source code that specializes in simplifying a code
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # Detects when assignments to existing variables are not used
     - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    - unused # Checks Go code for unused constants, variables, functions and types
     #
     ## disabled by default
     #

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -198,15 +198,13 @@ linters:
   enable:
     ## enabled by default
     #
-    - deadcode # Finds unused code
+    - unused # Finds unused code
     - gosimple # Linter for Go source code that specializes in simplifying a code
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # Detects when assignments to existing variables are not used
     - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck # Finds unused struct fields
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unused # Checks Go code for unused constants, variables, functions and types
-    - varcheck # Finds unused global variables and constants
     #
     ## disabled by default
     #


### PR DESCRIPTION
### Description

Since golangci-lint v1.49.0 the linters deadcode, structcheck and
varcheck are deprecated in favor of unused.

@dopey Consider also using 1.49.0 by default as is the version that was used in the last `step` release, see [this run](https://github.com/smallstep/cli/runs/8027311763?check_suite_focus=true#step:5:26).