### PR TITLE
Go version on linters

### DIFF
--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -9,14 +9,11 @@ jobs:
       matrix:
         go: ['1.18', '1.19']
     steps:
-      -
-        name: Install Go
+      - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      -
-        name: Checkout Code
+      - name: Checkout Code
         uses: actions/checkout@v3
-      -
-        name: Build
+      - name: Build
         run: V=1 make build

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Setup Go
         uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Configure Linter

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -9,32 +9,26 @@ jobs:
       matrix:
         go: ['1.18', '1.19']
     steps:
-      -
-        name: Install Go
+      - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      -
-        name: Install gotestsum
+      - name: Install gotestsum
         run: |
           go install gotest.tools/gotestsum@v1.8.1
-      -
-        name: Checkout Code
+      - name: Checkout Code
         uses: actions/checkout@v3
-      -
-        name: Run Test Suite
+      - name: Run Test Suite
         run: |
           gotestsum -- -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
         env:
           GOTESTSUM_JSONFILE: gotestsum.json
-      -
-        name: Annotate Test Suite Results
+      - name: Annotate Test Suite Results
         if: ${{ (success() || failure()) && hashFiles('gotestsum.json') != '' }}
         uses: guyarb/golang-test-annotations@v0.5.1
         with:
           test-results: gotestsum.json
-      -
-        name: Codecov
+      - name: Codecov
         uses: codecov/codecov-action@v1.2.1
         if: matrix.go == '1.19'
         with:


### PR DESCRIPTION
### Description

Because the go version is not set, the default behavior of `actions/setup-go@v3` is to use a version in the cache if present. There are runs like [this](https://github.com/smallstep/cli/runs/8028595433?check_suite_focus=true#step:2:8) where the version installed is 1.17.13. The linter fails in a code with generics that was introduced in 1.18.