### PR TITLE
go: enable cache during setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ trim_trailing_whitespace = true
 
 [*.yml]
 indent_size = 2
+indent_style = space

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -57,5 +57,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+          cache: true
       - name: Build
         run: V=1 make build

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           go-version: 1.19
           check-latest: true
+          cache: true
       - name: Configure Linter
         if:  ${{ hashFiles('.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json') == '' }}
         run: |

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+          cache: true
       - name: Install gotestsum
         run: |
           go install gotest.tools/gotestsum@v1.8.1

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           go-version: 1.19
           check-latest: true
+          cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck


### PR DESCRIPTION
This PR enables the cache for `actions/setup-go@v3`. More info on the cache may be found [here](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs).