### PR TITLE
goLint: bump golangci-lint version to v1.50

### DIFF
--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -62,5 +62,5 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49
+          version: v1.50
           args: --timeout=30m


### PR DESCRIPTION
This PR bumps the version of `golangci-lint` to [`v1.50`](https://github.com/golangci/golangci-lint/releases).