### PR TITLE
Convert all go-versions to strings

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
           check-latest: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
           check-latest: true
           cache: true
       - name: Setup SSH key for private dependencies

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
           check-latest: true
           cache: true
       - name: Setup SSH key for private dependencies


### PR DESCRIPTION
### Description

This avoids interpreting 1.20 as 1.2 because it is yaml. This might be a partial fix, there might be still a problem in the go matrix. I will know after applying this and test.
