### PR TITLE
Use "'1.20'" in go-matrixes

### DIFF
--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -24,12 +24,12 @@ jobs:
         id: set-matrix-latest
         if: inputs.only-latest-golang
         run: |
-          echo "matrix={\"include\":[{\"go\":\"1.20\"}]}" >> ${GITHUB_ENV}
+          echo "matrix={\"include\":[{\"go\":\"'1.20'\"}]}" >> ${GITHUB_ENV}
       - name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
         run: |
-          echo "matrix={\"include\":[{\"go\":\"1.19\"},{\"go\":\"1.20\"}]}" >> ${GITHUB_ENV}
+          echo "matrix={\"include\":[{\"go\":\"'1.19'\"},{\"go\":\"'1.20'\"}]}" >> ${GITHUB_ENV}
       - id: set-output
         run: |
           echo "matrix=${{ env.matrix }}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -29,12 +29,12 @@ jobs:
         id: set-matrix-latest
         if: inputs.only-latest-golang
         run: |
-          echo "matrix={\"include\":[{\"go\":\"1.20\"}]}" >> ${GITHUB_ENV}
+          echo "matrix={\"include\":[{\"go\":\"'1.20'\"}]}" >> ${GITHUB_ENV}
       - name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
         run: |
-          echo "matrix={\"include\":[{\"go\":\"1.19\"},{\"go\":\"1.20\"}]}" >> ${GITHUB_ENV}
+          echo "matrix={\"include\":[{\"go\":\"'1.19'\"},{\"go\":\"'1.20'\"}]}" >> ${GITHUB_ENV}
       - id: set-output
         run: |
           echo "matrix=${{ env.matrix }}" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
This commit tries to avoid interpreting the matrix value as 1.2, even if the matrix is rendered as:

```yaml
env:
  matrix: {"include":[{"go":"1.19"},{"go":"1.20"}]}
```
