### PR TITLE
Exclude `go-attestation` from forbidden replacements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,7 @@ linters-settings:
       - go.mozilla.org/pkcs7
       - go.step.sm/rpc
       - github.com/elimity-com/scim
+      - github.com/google/go-attestation # temporarily replaced with github.com/smallstep/go-attestation till changes are in upstream
 
   govet:
     check-shadowing: true


### PR DESCRIPTION
Needed to get https://github.com/smallstep/crypto/actions/runs/4179042315/jobs/7238535996 to pass