### PR TITLE
Use GoReleaser Pro

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,8 @@ on:
         required: false
       GORELEASER_PAT:
         required: true
+      GORELEASER_KEY:
+        required: true
       PAT:
         required: false
 
@@ -69,13 +71,15 @@ jobs:
         run: |
           RELEASE_DATE=$(date -u +"%y-%m-%d")
           echo "RELEASE_DATE=${RELEASE_DATE}" >> ${GITHUB_ENV}
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+      - name: Run GoReleaser Pro
+        uses: goreleaser/goreleaser-action@v5
         with:
-          version: 'latest'
+          distribution: goreleaser-pro
+          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           RELEASE_DATE: ${{ env.RELEASE_DATE }}
           COSIGN_EXPERIMENTAL: 1
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -42,6 +42,9 @@ jobs:
           sudo apt-get install ${{ inputs.os-dependencies }}
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           sudo apt-get install ${{ inputs.os-dependencies }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git fetch --force --tags


### PR DESCRIPTION
The first commit just adds GoReleaser Pro.

The second commit adjusts the git checkout step for the action, because [GoReleaser’s docs strongly recommend it](https://goreleaser.com/ci/actions/#workflow). It uses fetch depth 0 instead of a full checkout, and now will run `git fetch --force -tags` as well. I hope this interoperates well with the rest of the Action, specifically our use of SSH & private dependencies in some cases 🤞🏼 