### PR TITLE
remove github-token secret from dependabot-auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,9 +2,6 @@ name: Dependabot auto-merge
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 permissions:
   contents: write


### PR DESCRIPTION
collides with github action system secret
