### PR TITLE
Allow to pass docker build arguments

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: string
         default: Dockerfile
+      docker_build_args:
+        required: false
+        type: string
       runs_on:
         required: false
         type: string
@@ -61,6 +64,7 @@ jobs:
           push: true
           tags: ${{ inputs.tags }}
           platforms: ${{ inputs.platforms }}
+          build-args: ${{ inputs.docker_build_args }}
       - name: Cosign
         id: cosign
         run: |


### PR DESCRIPTION
This PR allows to pass build arguments to docker to fill ARG values in a Dockerfile. This can be useful to build distroless images using builders that do not have make, git, ...
