### PR TITLE
Add env var for test run due to go 1.22 regression

### DIFF
--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -117,6 +117,7 @@ jobs:
         run: ${{ inputs.test-command }}
         env:
           GOTESTSUM_JSONFILE: gotestsum.json
+          GOEXPERIMENT: nocoverageredesign
       -
         name: Annotate Test Suite Results
         if: ${{ (success() || failure()) && hashFiles('gotestsum.json') != '' }}


### PR DESCRIPTION
- should be able to remove this once Golang patches the issue