### PR TITLE
golangci-lint: do NOT skip pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,10 +3,6 @@ run:
   # Default: 1m
   timeout: 3m
 
-  skip-dirs:
-    - pkg
-
-
 # This file contains only configs which differ from defaults.
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:


### PR DESCRIPTION
This PR removes the exclusion of `pkg` from the linting process.