### PR TITLE
Lint Go tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 3m
+  modules-download-mode: readonly
+  tests: true
+  timeout: 5m
 
 # This file contains only configs which differ from defaults.
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml


### PR DESCRIPTION
This PR enables linting of tests by default. It also sets the `go mod download` mode to `readonly`.