### PR TITLE
Upgrade `cosign` to `v2.2.3`

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.2.3'
       - name: Build and push
         id: build-and-push
         uses: docker/build-push-action@v5

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,7 +4,7 @@ on:
       cosign-version:
         required: false
         type: string
-        default: 'v1.13.1'
+        default: 'v2.2.3'
       goprivate:
         required: false
         type: string


### PR DESCRIPTION
Sigstore announced they were [going to use a new TUF](https://blog.sigstore.dev/tuf-root-update/ ) root last week and asked to update Cosign versions. Older Cosign versions will fail signing.