### PR TITLE
Remove `COSIGN_EXPERIMENTAL` env var

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -69,5 +69,3 @@ jobs:
         id: cosign
         run: |
           cosign sign -r ${{ inputs.docker_image }}@${{ steps.build-and-push.outputs.digest }} --yes
-        env:
-          COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -84,6 +84,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           RELEASE_DATE: ${{ env.RELEASE_DATE }}
-          COSIGN_EXPERIMENTAL: 1
 
 


### PR DESCRIPTION
Starting with Cosign `v2.x`, keyless signing is the default

See https://blog.sigstore.dev/cosign-2-0-released/