### PR TITLE
Set up Go stable in CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,6 +38,12 @@ jobs:
       with:
         submodules: true
         ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 'stable'
+        check-latest: true
+        cache: true
     - name: Setup SSH key for private dependencies
       uses: webfactory/ssh-agent@v0.9.0
       env:


### PR DESCRIPTION
Make sure to use Go stable instead of current default for codeql action Go 1.21.

See https://github.com/github/codeql/issues/15647#issuecomment-2003768106
