### PR TITLE
Remove deprecated govet option

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,7 +129,6 @@ linters-settings:
       - github.com/google/go-attestation # temporarily replaced with github.com/smallstep/go-attestation till changes are in upstream
 
   govet:
-    check-shadowing: true
     # Enable all analyzers.
     # Default: false
     enable-all: true


### PR DESCRIPTION
This commit removes the deprecated option linters.govet.check-shadowing that causes a warning when running golangci-lint without the environment variable `LOG_LEVEL=error`

The warning shows:
```
WARN [config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.
```