### PR TITLE
goLint: add a check that go.mod is tidied

### DIFF
--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -59,7 +59,15 @@ jobs:
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
+      - name: Check that go.mod is tidied
+        run: |
+          cp go.mod go.mod.orig
+          cp go.sum go.sum.orig
+          go mod tidy
+          diff go.mod go.mod.orig
+          diff go.sum go.sum.orig
       - name: Run Linter
+        if: success() || failure() # run this step even if the previous one failed
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           version: v1.59.1


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Check that `go.mod` is tidied.

#### Pain or issue this feature alleviates:

There's no reason to commit a `go.mod` that is not tidied.

#### Why is this important to the project (if not answered above):

Best case an untidy `go.mod` pulls in dependencies that are not needed, worst case it leads to build failures due to incorrect module hashes.

#### Is there documentation on how to use this feature? If so, where?

https://go.dev/ref/mod#go-mod-tidy

#### In what environments or workflows is this feature supported?

All of them.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

None.

#### Supporting links/other PRs/issues:

I've been [running this logic in quic-go](https://github.com/quic-go/quic-go/blob/v0.45.1/.github/workflows/lint.yml#L21-L28)  for a long time.

💔Thank you!
