### PR TITLE
Add support in for signing and publishing RPM and Deb packages to GCP Artifact Registry

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -43,6 +43,8 @@ on:
         required: false
       GPG_PRIVATE_KEY:
         required: false
+      GPG_PRIVATE_KEY_PASSWORD:
+        required: false
       GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER:
         required: false
       GOOGLE_CLOUD_GITHUB_SERVICE_ACCOUNT:
@@ -50,15 +52,11 @@ on:
       GOOGLE_CLOUD_PACKAGES_PROJECT_ID:
         required: false
 
+
 jobs:
   goreleaser:
-<<<<<<< HEAD
     name: Upload Assets To Github w/ goreleaser
     runs-on: ${{ inputs.runs-on }}
-=======
-    name: Upload Assets To Github and Google Artifact Registry w/ goreleaser
-    runs-on: ubuntu-latest
->>>>>>> 660f1cc (Add support in for signing and publishing RPM and Deb packages to GCP Artifact Registry.)
     permissions:
       id-token: write
       contents: write
@@ -126,6 +124,7 @@ jobs:
         shell: bash
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
       - name: Run GoReleaser Pro
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -132,11 +132,11 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_S3_REGION: ${{ secrets.AWS_S3_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          NFPM_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
           RELEASE_DATE: ${{ env.RELEASE_DATE }}
-

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -37,16 +37,25 @@ on:
         required: false
       AWS_SECRET_ACCESS_KEY:
         required: false
+      GPG_PRIVATE_KEY:
+        required: false
 
 jobs:
   goreleaser:
+<<<<<<< HEAD
     name: Upload Assets To Github w/ goreleaser
     runs-on: ${{ inputs.runs-on }}
+=======
+    name: Upload Assets To Github and Google Artifact Registry w/ goreleaser
+    runs-on: ubuntu-latest
+>>>>>>> 660f1cc (Add support in for signing and publishing RPM and Deb packages to GCP Artifact Registry.)
     permissions:
       id-token: write
       contents: write
+      packages: write
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
+      GPG_PRIVATE_KEY_FILE: "0x889B19391F774443-Certify.key"
     steps:
       - name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
@@ -87,6 +96,23 @@ jobs:
         run: |
           RELEASE_DATE=$(date -u +"%y-%m-%d")
           echo "RELEASE_DATE=${RELEASE_DATE}" >> "${GITHUB_ENV}"
+      - name: Authenticate to Google Cloud
+        id: gcloud-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_CLOUD_GITHUB_SERVICE_ACCOUNT }}
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: prod-us-central1-e5bd
+      - name: Write GPG private key to file
+        run: |
+          echo "${GPG_PRIVATE_KEY}" > "${GPG_PRIVATE_KEY_FILE}"
+        shell: bash
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Run GoReleaser Pro
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: prod-us-central1-e5bd
+          project_id: ${{ secrets.GOOGLE_CLOUD_PACKAGES_PROJECT_ID }}
       - name: Write GPG private key to file
         run: |
           echo "${GPG_PRIVATE_KEY}" > "${GPG_PRIVATE_KEY_FILE}"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -44,7 +44,7 @@ on:
       GPG_PRIVATE_KEY:
         required: false
       GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER:
-        required: true
+        required: false
       GOOGLE_CLOUD_GITHUB_SERVICE_ACCOUNT:
         required: false
       GOOGLE_CLOUD_PACKAGES_PROJECT_ID:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -39,6 +39,12 @@ on:
         required: false
       GPG_PRIVATE_KEY:
         required: false
+      GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GOOGLE_CLOUD_GITHUB_SERVICE_ACCOUNT:
+        required: false
+      GOOGLE_CLOUD_PACKAGES_PROJECT_ID:
+        required: false
 
 jobs:
   goreleaser:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,6 +5,10 @@ on:
         required: false
         type: string
         default: 'v2.2.3'
+      enable-packages-upload:
+        required: false
+        type: boolean
+        default: false
       goprivate:
         required: false
         type: string
@@ -103,6 +107,7 @@ jobs:
           RELEASE_DATE=$(date -u +"%y-%m-%d")
           echo "RELEASE_DATE=${RELEASE_DATE}" >> "${GITHUB_ENV}"
       - name: Authenticate to Google Cloud
+        if: inputs.enable-packages-upload
         id: gcloud-auth
         uses: google-github-actions/auth@v2
         with:
@@ -110,10 +115,12 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_CLOUD_GITHUB_SERVICE_ACCOUNT }}
       - name: Set up Google Cloud SDK
+        if: inputs.enable-packages-upload
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GOOGLE_CLOUD_PACKAGES_PROJECT_ID }}
       - name: Write GPG private key to file
+        if: inputs.enable-packages-upload
         run: |
           echo "${GPG_PRIVATE_KEY}" > "${GPG_PRIVATE_KEY_FILE}"
         shell: bash


### PR DESCRIPTION
This PR enables setting up the needed things for GoReleaser to be able to sign RPM and Deb packages and upload them to GCP Artifact Registry