### PR TITLE
Upgrade golangci-lint version

### DIFF
--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.59.1
+          version: v1.60.1
           args: '${{ inputs.golangci-lint-args }}'
           skip-cache: true


### PR DESCRIPTION
This commit upgrades golangci-lint version to the latest release. This version includes support for Go 1.23, but seems to solve OOM errors or timeouts on repos using Go 1.23.

This version will show govet errors that weren't there before.
