### PR TITLE
Exclude generated protobuf code from being checked in linter

### DIFF
--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Run go generate
         if: success() || failure() # run this step even if the previous one failed
         run: |
-          # delete all go-generated files (that adhere to the comment convention)
-          git ls-files -z | grep --include \*.go -lrIZ "^// Code generated .* DO NOT EDIT\.$" | tr '\0' '\n' | xargs rm -f
+          # delete all go-generated files (that adhere to the comment convention); protobuf code is excluded, because its output is (currently) not fully controlled by tools.go
+          git ls-files -z | grep --include \*.go --exclude \*.pb.go -lrIZ "^// Code generated .* DO NOT EDIT\.$" | tr '\0' '\n' | xargs rm -f
           # now generate everything
           go generate ./...
           # check if any files were changed


### PR DESCRIPTION
https://github.com/smallstep/linkedca/pull/103 fails because Protobuf code generation results in a diff. `protoc-gen-go` can be versioned using `tools.go`, but `protoc` cannot. This can result in different versions being set in the generated code, resulting in a diff. Exclude the generated protobuf code (for now) from being checked in CI.

If we want to improve on this we may want to setup `protoc` similar to this CI workflow: https://github.com/smallstep/protobufs/blob/main/.github/workflows/test.yml#L17-L27. The way it works now (afaik) would require the protobuf code to be generated locally with the same versions at all times. It would be nice if the actual code generation and committing that for `linkedca` would be done in CI too, so that there's no potential version mismatch.