### PR TITLE
goLint: use the version of Go the module defines

### DIFF
--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -11,11 +11,11 @@ on:
       golangci-lint-version:
         required: false
         type: string
-        default: '--timeout=30m'
+        default: v1.60.1
       golangci-lint-args:
         required: false
         type: string
-        default: v1.60.1
+        default: '--timeout=30m'
       goprivate:
         required: false
         type: string

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -8,10 +8,14 @@ on:
       codeql-make-bootstrap:
         required: false
         type: boolean
-      golangci-lint-args:
+      golangci-lint-version:
         required: false
         type: string
         default: '--timeout=30m'
+      golangci-lint-args:
+        required: false
+        type: string
+        default: v1.60.1
       goprivate:
         required: false
         type: string
@@ -87,6 +91,7 @@ jobs:
     if: inputs.run-lint
     with:
       goprivate: ${{ inputs.goprivate }}
+      golangci-lint-version: ${{ inputs.golangci-lint-version }}
       golangci-lint-args: ${{ inputs.golangci-lint-args }}
       os-dependencies: ${{ inputs.os-dependencies }}
       skip-go-generate: ${{ inputs.lint-skip-go-generate }}

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: go.step.sm,github.com/smallstep
+      golangci-lint-version:
+        required: false
+        type: string
+        default: v1.60.1
       golangci-lint-args:
         required: false
         type: string
@@ -41,9 +45,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 'stable'
+          go-version-file: go.mod
           check-latest: true
-          cache: true
       - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         env:
@@ -66,9 +69,8 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@2e788936b09dd82dc280e845628a40d2ba6b204c # v6.3.1
         with:
-          version: v1.60.1
+          version: ${{ inputs.golangci-lint-version }}
           args: '${{ inputs.golangci-lint-args }}'
-          skip-cache: true
       - name: Run go generate
         if: ( success() || failure() ) && !inputs.skip-go-generate
         run: |


### PR DESCRIPTION
This PR alters `goLint.yml` so that it uses the version of Go the module defines in its `go.mod`, when setting up Go.

It also introduces a way to define the version of `golangci-lint` that each build wants to use.