### PR TITLE
goLint: Replace the exportloopref & tenv linters with copyloopvar & usetesting respectively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,14 @@ name: CI
 
 on:
   push:
+    tags-ignore:
+      - "**"
+    branches:
+      - main
   pull_request:
+    types:
+      - opened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,16 +27,20 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 'stable'
+          go-version-file: lintapp/go.mod
           check-latest: true
-          cache: true
+
       - name: Install golangci-lint # TODO: replace with golangci-lint action or fully deprecate in favor of goLint.yml?
         run: |
           curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" v1.64.4
-      - name: Lint golangci-lint.yml config
-        run: |
-          "$(go env GOPATH)/bin/golangci-lint" config verify
 
+      - name: Lint golangci-lint.yml config
+        run: golangci-lint config verify -v --config .golangci.yml
+
+      - name: Lint dummy app
+        working-directory: lintapp
+        run: golangci-lint run --config ../.golangci.yml -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -176,7 +176,7 @@ linters:
     - durationcheck # check for two durations multiplied together
     - errname # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exportloopref # checks for pointers to enclosing loop variables
+    - copyloopvar # detects places where loop variables are copied.
     - decorder # check declaration order and count of types, constants, variables and functions
     - gocritic # Provides diagnostics that check for bugs, performance and style issues.
     - goheader # Checks if file header matches to pattern
@@ -196,7 +196,7 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully
     - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed.
     - stylecheck # Stylecheck is a replacement for golint
-    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
+    - usetesting # reports uses of functions with replacement inside the testing package.
     - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.

--- a/lintapp/go.mod
+++ b/lintapp/go.mod
@@ -1,0 +1,3 @@
+module github.com/smallstep/workflows/lintapp
+
+go 1.23

--- a/lintapp/goapp.go
+++ b/lintapp/goapp.go
@@ -1,0 +1,8 @@
+// This is dummy package so that we check whether the golangci-lint checks work properly.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("dummy")
+}


### PR DESCRIPTION
This PR addresses the following warnings, that `golangci-lint run` produces:

```bash
level=warning msg="The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting."
level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
level=error msg="[linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports."
```

It additionally adds a sample (dummy) Go application that `golangci-lint` has to lint, in order to enforce that there's nothing wrong with its configuration.