### PR TITLE
Refactor the build to use the golangci-lint action

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   actionlint:
+    name: Lint GitHub workflows
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ concurrency:
 
 jobs:
   actionlint:
+    name: Lint GitHub workflows
     uses: ./.github/workflows/actionlint.yml
     secrets: inherit
 
-  lint-golangci-yml:
+  lint-dummy-app: # NOTE(@azazeal): this check is here to verify that .golangci.yml is valid
+    name: Lint dummy app
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,19 +30,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - name: Run Linter
+        uses: golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778 # v6.4.0
         with:
-          go-version-file: lintapp/go.mod
-          check-latest: true
-
-      - name: Install golangci-lint # TODO: replace with golangci-lint action or fully deprecate in favor of goLint.yml?
-        run: |
-          curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" v1.64.4
-
-      - name: Lint golangci-lint.yml config
-        run: golangci-lint config verify -v --config .golangci.yml
-
-      - name: Lint dummy app
-        working-directory: lintapp
-        run: golangci-lint run --config ../.golangci.yml -v ./...
+          working-directory: lintapp
+          version: latest
+          verify: true
+          args: --config=../.golangci.yml

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -11,7 +11,7 @@ on:
       golangci-lint-version:
         required: false
         type: string
-        default: v1.64.4
+        default: latest
       golangci-lint-args:
         required: false
         type: string

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -11,7 +11,7 @@ on:
       golangci-lint-version:
         required: false
         type: string
-        default: v1.64.4
+        default: latest
       golangci-lint-args:
         required: false
         type: string
@@ -67,10 +67,11 @@ jobs:
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
       - name: Run Linter
-        uses: golangci/golangci-lint-action@2e788936b09dd82dc280e845628a40d2ba6b204c # v6.3.1
+        uses: golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778 # v6.4.0
         with:
           version: ${{ inputs.golangci-lint-version }}
           args: '${{ inputs.golangci-lint-args }}'
+          verify: true
       - name: Run go generate
         if: ( success() || failure() ) && !inputs.skip-go-generate
         run: |


### PR DESCRIPTION
This PR refactors the build to use `golangci-lint-action` when linting and it also enables it's `verify` configuration option.