### PR TITLE
Remove obsolete tenv configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -148,12 +148,6 @@ linters-settings:
     packages:
       - github.com/jmoiron/sqlx
 
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
-
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
This PR removes the obsolete `tenv` configuration, since the linter was removed recently.