### PR TITLE
Golangci-lint V2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
 
       - name: Run Linter
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           working-directory: lintapp
           version: latest

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -79,7 +79,7 @@ jobs:
           diff go.mod go.mod.orig
           diff go.sum go.sum.orig
       - name: Run Linter
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         if: success() || failure() # run this step even if the previous one failed
         with:
           version: ${{ inputs.golangci-lint-version }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,258 +1,229 @@
+# This file contains only configs which differ from defaults.
+# All possible options can be found here: https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+version: "2"
 run:
   modules-download-mode: readonly
   tests: true
-  timeout: 5m
-
-# This file contains only configs which differ from defaults.
-# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-linters-settings:
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 30
-    # The maximal average package complexity.
-    # If it's higher than 0.0 (float) the check is enabled
-    # Default: 0.0
-    package-average: 10.0
-
-  dupl:
-    threshold: 100
-
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
-
-  funlen:
-    # Checks the number of lines in a function.
-    # If lower than 0, disable the check.
-    # Default: 60
-    lines: 100
-    # Checks the number of statements in a function.
-    # If lower than 0, disable the check.
-    # Default: 40
-    statements: 50
-
-  gocognit:
-    # Minimal code complexity to report
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
-
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-      - diagnostic
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      captLocal:
+linters:
+  default: none
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - durationcheck
+    - errname
+    - errorlint
+    - gocritic
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - gosec
+    - govet
+    - ineffassign
+    - makezero
+    - misspell
+    - nilerr
+    - nilnil
+    - nolintlint
+    - nosprintfhostport
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unused
+    - usetesting
+    - wastedassign
+    - whitespace
+  settings:
+    cyclop:
+     # The maximal code complexity to report.
+     # Default: 10
+      max-complexity: 30
+      # The maximal average package complexity.
+      # If it's higher than 0.0 (float) the check is enabled
+      # Default: 0.0
+      package-average: 10
+    dupl:
+      threshold: 100
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: true
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+    gocognit:
+      # Minimal code complexity to report
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 20
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - commentFormatting
+        - commentedOutCode
+        - hugeParam
+        - octalLiteral
+        - rangeValCopy
+        - tooManyResultsChecker
+        - unnamedResult
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+        - diagnostic
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be find in https://go-critic.github.io/overview.
+      settings:
         # Whether to restrict checker to params only.
         # Default: true
-        paramsOnly: false
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        # Default: true
-        skipRecvDeref: false
-    disabled-checks:
-      - commentFormatting
-      - commentedOutCode
-      - hugeParam
-      - octalLiteral
-      - rangeValCopy
-      - tooManyResultsChecker
-      - unnamedResult
-
-  gocyclo:
-    min-complexity: 10
-
-  gomodguard:
-    blocked:
-      # List of blocked modules.
+        captLocal:
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+    gocyclo:
+      min-complexity: 10
+    gomoddirectives:
+      replace-allow-list:
+        - go.mozilla.org/pkcs7
+        - go.step.sm/rpc
+        - github.com/elimity-com/scim
+        - github.com/google/go-attestation # temporarily replaced with github.com/smallstep/go-attestation till changes are in upstream
+      replace-local: true
+    gomodguard:
+      blocked:
+        # List of blocked modules.
+        # Default: []
+        modules:
+          - github.com/golang/protobuf:
+              recommendations:
+                - google.golang.org/protobuf
+              reason: see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+          - github.com/satori/go.uuid:
+              recommendations:
+                - github.com/google/uuid
+              reason: satori's package is not maintained
+          - github.com/gofrs/uuid:
+              recommendations:
+                - github.com/google/uuid
+              reason: 'see recommendation from dev-infra team: https://confluence.gtforge.com/x/gQI6Aw'
+    govet:
+      # Disable analyzers by name.
+      # Run `go tool vet help` to see all analyzers.
       # Default: []
-      modules:
-        - github.com/golang/protobuf:
-            recommendations:
-              - google.golang.org/protobuf
-            reason: "see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
-        - github.com/satori/go.uuid:
-            recommendations:
-              - github.com/google/uuid
-            reason: "satori's package is not maintained"
-        - github.com/gofrs/uuid:
-            recommendations:
-              - github.com/google/uuid
-            reason: "see recommendation from dev-infra team: https://confluence.gtforge.com/x/gQI6Aw"
-
-  gomoddirectives:
-    replace-local: true
-    replace-allow-list:
-      - go.mozilla.org/pkcs7
-      - go.step.sm/rpc
-      - github.com/elimity-com/scim
-      - github.com/google/go-attestation # temporarily replaced with github.com/smallstep/go-attestation till changes are in upstream
-
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    # Default: []
-    disable:
-      - fieldalignment # too strict
-    # Settings per analyzer.
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-
-  lll:
-    line-length: 140
-
-  misspell:
-    locale: US
-
-  nakedret:
+      disable:
+        - fieldalignment
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Settings per analyzer.
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
     # Make an issue if func has more lines of code than this setting, and it has naked returns.
     # Default: 30
-    max-func-lines: 0
-
-  nolintlint:
-    # Exclude following linters from requiring an explanation.
-    # Default: []
-    allow-no-explanation: [ funlen, gocognit, lll ]
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-
-  revive:
-    confidence: 0
-
-  rowserrcheck:
-    # database/sql is always checked
-    # Default: []
-    packages:
-      - github.com/jmoiron/sqlx
-
-linters:
-  disable-all: true
-  enable:
-    ## enabled by default
-    #
-    - unused # Checks Go code for unused constants, variables, functions and types
-    - gosimple # Linter for Go source code that specializes in simplifying a code
-    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # Detects when assignments to existing variables are not used
-    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    #
-    ## disabled by default
-    #
-    - asasalint # Check for pass []any as any in variadic func(...any)
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - bidichk # Checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - contextcheck # check the function whether use a non-inherited context
-    - durationcheck # check for two durations multiplied together
-    - errname # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
-    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - copyloopvar # detects places where loop variables are copied.
-    - decorder # check declaration order and count of types, constants, variables and functions
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - goheader # Checks if file header matches to pattern
-    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
-    - gosec # Inspects source code for security problems
-    - makezero # Finds slice declarations with non-zero initial length
-    - misspell # Finds commonly misspelled English words in comments
-    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
-    - nilnil # Checks that there is no simultaneous return of nil error and an invalid value.
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL.
-    - predeclared # find code that shadows one of Go's predeclared identifiers
-    - promlinter # Check Prometheus metrics naming via promlint
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed.
-    - stylecheck # Stylecheck is a replacement for golint
-    - usetesting # reports uses of functions with replacement inside the testing package.
-    - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
-    - unconvert # Remove unnecessary type conversions
-    - wastedassign # wastedassign finds wasted assignment statements.
-    - whitespace # Tool for detection of leading and trailing whitespace
-    #
-    ## Consider Enabling
-    #
-    #- cyclop # checks function and package cyclomatic complexity
-    #- dupl # Tool for code clone detection
-    #- errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    #- exhaustive # check exhaustiveness of enum switch statements
-    #- forbidigo # Forbids identifiers
-    #- funlen # Tool for detection of long functions
-    #- gochecknoglobals # check that no global variables exist
-    #- gochecknoinits # Checks that no init functions are present in Go code
-    #- gocognit # Computes and checks the cognitive complexity of functions
-    #- goconst # Finds repeated strings that could be replaced by a constant
-    #- gocyclo # Computes and checks the cyclomatic complexity of functions
-    #- godot # Check if comments end in a period
-    #- gomnd # An analyzer to detect magic numbers.
-    #- goprintffuncname # Checks that printf-like functions are named with f at the end - usefulness is dubious.
-    #- lll # Reports long lines
-    #- nakedret # Finds naked returns in functions greater than a specified function length
-    #- nestif # Reports deeply nested if statements
-    #- noctx # noctx finds sending http request without context.Context
-    #- nonamedreturns # Reports all named returns
-    #- testpackage # linter that makes you use a separate _test package
-    #- unparam # Reports unused function parameters
-    #- wrapcheck # Checks that errors returned from external packages are wrapped you may want to enable
-    #- exhaustruct # Checks if all structure fields are initialized
-    #- ireturn # Accept Interfaces, Return Concrete Types
-    #- prealloc # [premature optimization, but can be used in some cases] Finds slice declarations that could potentially be preallocated
-    #
-    ## disabled
-    #
-    #- containedctx # containedctx is a linter that detects struct contained context.Context field
-    #- depguard # [replaced by gomodguard] Go linter that checks if package imports are in a list of acceptable packages
-    #- dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
-    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted.
-    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
-    #- gci # Gci controls golang package import order and makes it always deterministic.
-    #- godox # Tool for detection of FIXME, TODO and other comment keywords
-    #- goerr113 # [too strict] Golang linter to check the errors handling expressions
-    #- gofmt # [replaced by goimports] Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    #- gofumpt # [replaced by goimports, gofumports is not available yet] Gofumpt checks whether code was gofumpt-ed.
-    #- grouper # An analyzer to analyze expression groups.
-    #- ifshort # Checks that your code uses short syntax for if-statements whenever possible
-    #- importas # Enforces consistent import aliases
-    #- maintidx # maintidx measures the maintainability index of each function.
-    #- nlreturn # [too strict and mostly code is not more readable] nlreturn checks for a new line before return and branch statements to increase code clarity
-    #- nosnakecase # Detects snake case of variable naming and function name. # TODO: maybe enable after https://github.com/sivchari/nosnakecase/issues/14
-    #- paralleltest # [too many false positives] paralleltest detects missing usage of t.Parallel() method in your Go test
-    #- tagliatelle # Checks the struct tags.
-    #- thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    #- wsl # [too strict and mostly code is not more readable] Whitespace Linter - Forces you to use empty lines!
-    ## deprecated
-    #- exhaustivestruct # [deprecated, replaced by exhaustruct] Checks if all struct's fields are initialized
-    #- golint # [deprecated, replaced by revive] Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    #- interfacer # [deprecated] Linter that suggests narrower interface types
-    #- maligned # [deprecated, replaced by govet fieldalignment] Tool to detect Go structs that would take less memory if their fields were sorted
-    #- scopelint # [deprecated, replaced by exportloopref] Scopelint checks for unpinned variables in go programs
-    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    nakedret:
+      max-func-lines: 0
+    nolintlint:
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation:
+        - funlen
+        - gocognit
+        - lll
+    revive:
+      confidence: 0
+    rowserrcheck:
+      # database/sql is always checked
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: ^//\s*go:generate\s
+      - linters:
+          - godot
+        source: (noinspection|TODO)
+      - linters:
+          - gocritic
+        source: //noinspection
+      - linters:
+          - errorlint
+        source: ^\s+if _, ok := err\.\([^.]+\.InternalError\); ok {
+      - linters:
+          - bodyclose
+          - contextcheck
+          - dupl
+          - errcheck
+          - funlen
+          - goconst
+          - gosec
+          - nilnil
+          - noctx
+          - nolintlint
+          - revive
+          - whitespace
+          - wrapcheck
+        path: _test\.go
+      - path: (.+)\.go$
+        text: declaration of "err" shadows declaration at line
+      - path: (.+)\.go$
+        text: should have a package comment, unless it's in another file for this package
+      - path: (.+)\.go$
+        text: func `CLICommand.
+      - path: (.+)\.go$
+        text: error strings should not be capitalized or end with punctuation or a newline
+      - path: (.+)\.go$
+        text: Function `URLParam->URLParam` should pass the context parameter
+      - path: (.+)\.go$
+        text: Function `URLParam` should pass the context parameter
+      - path: (.+)\.go$
+        text: Potentially accessing slice out of bounds
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   # Maximum count of issues with the same text.
@@ -260,36 +231,12 @@ issues:
   # Default: 3
   max-same-issues: 50
 
-  exclude:
-    - declaration of "err" shadows declaration at line
-    - should have a package comment, unless it's in another file for this package
-    - func `CLICommand.
-    - error strings should not be capitalized or end with punctuation or a newline
-    - Function `URLParam->URLParam` should pass the context parameter
-    - Function `URLParam` should pass the context parameter
-    - Potentially accessing slice out of bounds
-
-  exclude-rules:
-    - source: "^//\\s*go:generate\\s"
-      linters: [ lll ]
-    - source: "(noinspection|TODO)"
-      linters: [ godot ]
-    - source: "//noinspection"
-      linters: [ gocritic ]
-    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
-      linters: [ errorlint ]
-    - path: "_test\\.go"
-      linters:
-        - bodyclose
-        - contextcheck
-        - dupl
-        - errcheck
-        - funlen
-        - goconst
-        - gosec
-        - nilnil
-        - noctx
-        - nolintlint
-        - revive
-        - wrapcheck
-        - whitespace
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Replaces #212.

New configuration format created by running `golangci-lint migrate`. Comments were added back manually.