### PR TITLE
Disable nonsensical usetesting context linting rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -178,6 +178,9 @@ linters:
         # Omit embedded fields from selector expression.
         # https://staticcheck.dev/docs/checks/#QF1008
         - -QF1008
+    usetesting:
+      context-background: false
+      context-todo: false
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
`usetesting` enforces the use of `t.Context` everywhere, even in `t.Cleanup`. This is incorrect, as that context is cancelled just before `Cleanup` is called.

Furthermore, in many cases, `context.Background` is used like this:
```go
func TestSomething(t *testing.T) {
     err := doSomething(context.Background())
     require.NoError(t, err)
}
```
Here it doesn't make any difference if `context.Background` or `t.Context` is used: 
* In both cases, if `doSomething` doesn't block indefinitely, it will return eventually.
* In both cases, if `doSomething` blocks longer than the test timeout, `go test` will fail.

There are a few situations where `t.Context` is useful:
* Saving one LOC when using a `context.WithCancel`.
* When using a context in a Goroutine.

Also see https://github.com/smallstep/bouncer/pull/260.