### PR TITLE
Restore previous `govulncheck` conditional execution

### DIFF
--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -104,7 +104,7 @@ jobs:
 
   govulncheck:
     uses: ./.github/workflows/govulncheck.yml
-    if: true
+    if: inputs.run-govulncheck
     with:
       os-dependencies: ${{ inputs.os-dependencies }}
       goprivate: ${{ inputs.goprivate }}


### PR DESCRIPTION
Restores behavior from before https://github.com/smallstep/workflows/pull/238, which was a temporary fix to get CI going again.

Undoes https://github.com/smallstep/workflows/pull/254.