### PR TITLE
Add Cache to Go Tests

### DIFF
--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -100,7 +100,8 @@ jobs:
           chmod -R 0755 \
             ~/.cache/go-build \
             ~/go/pkg/mod
-      - name: Action Cache
+      - 
+        name: Action Cache
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -94,6 +94,20 @@ jobs:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
+      - name: chmod cache dir
+        run: |
+          chmod -R 0755 \
+            ~/.cache/go-build \
+            ~/go/pkg/mod
+      - name: Action Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       -
         name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -94,7 +94,8 @@ jobs:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
-      - name: chmod cache dir
+      - 
+        name: chmod cache dir
         run: |
           chmod -R 0755 \
             ~/.cache/go-build \


### PR DESCRIPTION
After some testing, it appears that the cache from [actions/setup-go](https://github.com/actions/setup-go) may not be working as expected. I did not find the root cause, but will open a discussion in that repo.

Tests run significantly faster with the addition of [actions/cache](https://github.com/actions/cache) (about 1 minute compared to sometimes 15). The main improvements seem to come from the modules getting cached properly now.

The cache directory is chmod'd to prevent write errors during untarring. [issue ref](https://github.com/orgs/community/discussions/58174#discussioncomment-8250884).

Thanks @dopey working on this as well.