### PR TITLE
Add support for `os-dependencies` to CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ on:
         required: false
         type: string
         default: go.step.sm,github.com/smallstep
+      os-dependencies:
+        required: false
+        type: string
     secrets:
       SSH_PRIVATE_KEY:
         required: false
@@ -37,6 +40,12 @@ jobs:
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     steps:
+      -
+        name: Install Dependencies
+        if: ${{ inputs.os-dependencies != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install ${{ inputs.os-dependencies }}
       -
         name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -119,6 +119,7 @@ jobs:
     uses: ./.github/workflows/codeql-analysis.yml
     with:
       goprivate: ${{ inputs.goprivate }}
+      os-dependencies: ${{ inputs.os-dependencies }}
       codeql-make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
       codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
     secrets: inherit


### PR DESCRIPTION
CI was broken in `crypto` due to CodeQL not being able to build. After setting the build command, and pointing it to this commit to allow installing dependencies, CI is green again: https://github.com/smallstep/crypto/pull/862, https://github.com/smallstep/crypto/actions/runs/18275865392.