### PR TITLE
gh: Add a codeql-build-mode input to CodeQL workflows

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -5,6 +5,14 @@ on:
         required: false
         type: boolean
         default: true
+      codeql-build-cmd:
+        required: false
+        type: string
+        default: 'V=1 make build'
+      codeql-build-mode:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   actions: read
@@ -15,3 +23,6 @@ jobs:
   codeql:
     if: inputs.run-codeql
     uses: ./.github/workflows/codeql-analysis.yml
+    with:
+      codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
+      codeql-build-mode: ${{ inputs.codeql-build-mode }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: 'V=1 make build'
+      codeql-build-mode:
+        required: false
+        type: string
+        default: ''
       goprivate:
         required: false
         type: string
@@ -99,6 +103,7 @@ jobs:
         uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ inputs.codeql-build-mode }}
           queries: security-and-quality     # use Canonical suite
           packs: codeql/go-queries          # and pin the official pack explicitly
       -
@@ -107,7 +112,12 @@ jobs:
         run: |
           make bootstrap
       -
+        # Run only when the selected build mode expects a manual build:
+        # - '' (unset) keeps legacy behavior for existing callers.
+        # - 'manual' means the caller wants this step to drive the build.
+        # 'autobuild' and 'none' are handled by codeql-action itself, so we skip.
         name: Build
+        if: inputs.codeql-build-mode == '' || inputs.codeql-build-mode == 'manual'
         env:
           CODEQL_BUILD_CMD: ${{ inputs.codeql-build-cmd }}
         run: |

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -9,6 +9,10 @@ on:
         required: false
         type: string
         default: 'V=1 make build'
+      codeql-build-mode:
+        required: false
+        type: string
+        default: ''
       codeql-make-bootstrap:
         required: false
         type: boolean
@@ -117,6 +121,7 @@ jobs:
       os-dependencies: ${{ inputs.os-dependencies }}
       codeql-make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
       codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
+      codeql-build-mode: ${{ inputs.codeql-build-mode }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
This PR adds a `codeql-build-mode` input to `codeql-analysis.yml`, `goCI.yml`, and `code-scan.yml` so callers can pick a CodeQL build mode (e.g. `autobuild`, `manual`, `none`) without forking these workflows.

The default is the empty string, which `codeql-action`'s `getOptionalInput` treats as `undefined` — so existing callers see no behavior change. Callers that want to opt out of `codeql-action`'s autobuild fallback (which detects a `Makefile` and runs `make`, even when `codeql-build-cmd` is set to a no-op) can now pass `codeql-build-mode: 'manual'` and provide their own Go-only build via `codeql-build-cmd: 'go build ./...'`.

The input name keeps the `codeql-` prefix used by the other CodeQL inputs (`codeql-build-cmd`, `codeql-make-bootstrap`); it's mapped to the action's unprefixed `build-mode` input only at the `codeql-analysis.yml` layer.

It also gates the `Build` step so it only runs when the selected mode expects a manual build — i.e. when `codeql-build-mode` is `''` (legacy back-compat) or `'manual'`. For `'autobuild'` and `'none'` the build is handled by `codeql-action` itself, so the manual `CODEQL_BUILD_CMD` would be redundant or conflicting.
