### PR TITLE
gh: Add the codeql-runs-on input to codeql workflows

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ''
+      codeql-runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
 
 permissions:
   actions: read
@@ -26,3 +30,4 @@ jobs:
     with:
       codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
       codeql-build-mode: ${{ inputs.codeql-build-mode }}
+      codeql-runs-on: ${{ inputs.codeql-runs-on }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      codeql-runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
       goprivate:
         required: false
         type: string
@@ -30,7 +34,7 @@ on:
 jobs:
   codeql-analyze:
     name: CodeQL Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.codeql-runs-on }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -16,6 +16,10 @@ on:
       codeql-make-bootstrap:
         required: false
         type: boolean
+      codeql-runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
       golangci-lint-version:
         required: false
         type: string
@@ -122,6 +126,7 @@ jobs:
       codeql-make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
       codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
       codeql-build-mode: ${{ inputs.codeql-build-mode }}
+      codeql-runs-on: ${{ inputs.codeql-runs-on }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
This PR adds a `codeql-runs-on` input to `codeql-analysis.yml`, `goCI.yml`, and `code-scan.yml` so callers can pick a larger runner for CodeQL without forking these workflows.

The default is `ubuntu-latest`, so existing callers see no behavior change. The input keeps the `codeql-` prefix used by the other CodeQL inputs (`codeql-build-cmd`, `codeql-build-mode`, `codeql-make-bootstrap`); it's mapped to the job's unprefixed `runs-on` only at the `codeql-analysis.yml` layer.
