### PR TITLE
Cascade runs-on and make CI workflows OS-aware

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -21,6 +21,14 @@ on:
         required: false
         type: string
         default: ''
+      os-dependencies:
+        required: false
+        type: string
+        default: ''
+      codeql-os-dependencies:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   actions: read
@@ -35,3 +43,4 @@ jobs:
       runs-on: ${{ inputs.codeql-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       build-cmd: ${{ inputs.codeql-build-cmd }}
       build-mode: ${{ inputs.codeql-build-mode }}
+      os-dependencies: ${{ inputs.codeql-os-dependencies || inputs.os-dependencies || '' }}

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -5,6 +5,10 @@ on:
         required: false
         type: boolean
         default: true
+      runs-on:
+        required: false
+        type: string
+        default: ''
       codeql-build-cmd:
         required: false
         type: string
@@ -16,7 +20,7 @@ on:
       codeql-runs-on:
         required: false
         type: string
-        default: ubuntu-latest
+        default: ''
 
 permissions:
   actions: read
@@ -28,6 +32,6 @@ jobs:
     if: inputs.run-codeql
     uses: ./.github/workflows/codeql-analysis.yml
     with:
-      codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
-      codeql-build-mode: ${{ inputs.codeql-build-mode }}
-      codeql-runs-on: ${{ inputs.codeql-runs-on }}
+      runs-on: ${{ inputs.codeql-runs-on || inputs.runs-on || 'ubuntu-latest' }}
+      build-cmd: ${{ inputs.codeql-build-cmd }}
+      build-mode: ${{ inputs.codeql-build-mode }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -80,6 +80,7 @@ jobs:
           go-version: 'stable'
           check-latest: true
           cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,48 +44,43 @@ jobs:
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     steps:
-      -
-        name: Install Dependencies
+      - name: Install Dependencies
         if: ${{ inputs.os-dependencies != '' }}
+        shell: bash
         env:
           OS_DEPS: ${{ inputs.os-dependencies }}
         run: |
-          sudo apt-get update
-          # shellcheck disable=SC2086
-          sudo apt-get install ${OS_DEPS}
-      -
-        name: Checkout
+          case "${RUNNER_OS}" in
+            Linux)
+              sudo apt-get update
+              # shellcheck disable=SC2086
+              sudo apt-get install -y ${OS_DEPS}
+              ;;
+            macOS)
+              # shellcheck disable=SC2086
+              brew install ${OS_DEPS}
+              ;;
+            Windows)
+              # shellcheck disable=SC2086
+              choco install -y ${OS_DEPS}
+              ;;
+            *)
+              echo "unsupported RUNNER_OS=${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
+          submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Setup Go
-        id: setup-go
+      - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
           check-latest: true
           cache: true
-      -
-        name: chmod cache dir
-        if: steps.setup-go.outputs.cache-hit == 'true'
-        run: |
-          chmod -R 0755 \
-            ~/.cache/go-build \
-            ~/go/pkg/mod || true
-      -
-        name: Action Cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      -
-        name: Setup SSH key for private dependencies
+      - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -93,41 +88,37 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Reconfigure Git for private repos
+      - name: Reconfigure Git for private repos
+        if: ${{ env.PAT != '' }}
         env:
           PAT: ${{ secrets.PAT }}
-        if: ${{ env.PAT != '' }}
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
-      -
-        # Initializes the CodeQL tools for scanning.
-        name: Initialize CodeQL
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
         uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ inputs.build-mode }}
-          queries: security-and-quality     # use Canonical suite
-          packs: codeql/go-queries          # and pin the official pack explicitly
-      -
-        name: Make bootstrap
+          queries: security-and-quality # use Canonical suite
+          packs: codeql/go-queries # and pin the official pack explicitly
+      - name: Make bootstrap
         if: inputs.make-bootstrap
         run: |
           make bootstrap
-      -
-        # Run only when the selected build mode expects a manual build:
-        # - '' (unset) keeps legacy behavior for existing callers.
-        # - 'manual' means the caller wants this step to drive the build.
-        # 'autobuild' and 'none' are handled by codeql-action itself, so we skip.
-        name: Build
+      # Run only when the selected build mode expects a manual build:
+      # - '' (unset) keeps legacy behavior for existing callers.
+      # - 'manual' means the caller wants this step to drive the build.
+      # 'autobuild' and 'none' are handled by codeql-action itself, so we skip.
+      - name: Build
         if: inputs.build-mode == '' || inputs.build-mode == 'manual'
+        shell: bash
         env:
           BUILD_CMD: ${{ inputs.build-cmd }}
         run: |
           eval "${BUILD_CMD}"
-      -
-        name: Perform CodeQL Analysis
+      - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           output: codeql-results

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,21 +3,21 @@ name: "CodeQL"
 on:
   workflow_call:
     inputs:
-      codeql-make-bootstrap:
-        required: false
-        type: boolean
-      codeql-build-cmd:
-        required: false
-        type: string
-        default: 'V=1 make build'
-      codeql-build-mode:
-        required: false
-        type: string
-        default: ''
-      codeql-runs-on:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
+      build-cmd:
+        required: false
+        type: string
+        default: 'V=1 make build'
+      build-mode:
+        required: false
+        type: string
+        default: ''
+      make-bootstrap:
+        required: false
+        type: boolean
       goprivate:
         required: false
         type: string
@@ -34,7 +34,7 @@ on:
 jobs:
   codeql-analyze:
     name: CodeQL Analyze
-    runs-on: ${{ inputs.codeql-runs-on }}
+    runs-on: ${{ inputs.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -107,12 +107,12 @@ jobs:
         uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           languages: ${{ matrix.language }}
-          build-mode: ${{ inputs.codeql-build-mode }}
+          build-mode: ${{ inputs.build-mode }}
           queries: security-and-quality     # use Canonical suite
           packs: codeql/go-queries          # and pin the official pack explicitly
       -
         name: Make bootstrap
-        if: inputs.codeql-make-bootstrap
+        if: inputs.make-bootstrap
         run: |
           make bootstrap
       -
@@ -121,11 +121,11 @@ jobs:
         # - 'manual' means the caller wants this step to drive the build.
         # 'autobuild' and 'none' are handled by codeql-action itself, so we skip.
         name: Build
-        if: inputs.codeql-build-mode == '' || inputs.codeql-build-mode == 'manual'
+        if: inputs.build-mode == '' || inputs.build-mode == 'manual'
         env:
-          CODEQL_BUILD_CMD: ${{ inputs.codeql-build-cmd }}
+          BUILD_CMD: ${{ inputs.build-cmd }}
         run: |
-          eval "${CODEQL_BUILD_CMD}"
+          eval "${BUILD_CMD}"
       -
         name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -35,14 +35,17 @@ jobs:
       - name: Set go-matrix latest version
         id: set-matrix-latest
         if: inputs.only-latest-golang
+        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""}]}' >> "${GITHUB_ENV}"
       - name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
+        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""},{"go":"\"oldstable\""}]}' >> "${GITHUB_ENV}"
       - id: set-output
+        shell: bash
         run: |
           echo "matrix=${{ env.matrix }}" >> "${GITHUB_OUTPUT}"
 
@@ -57,12 +60,29 @@ jobs:
       -
         name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
+        shell: bash
         env:
           OS_DEPS: ${{ inputs.os-dependencies }}
         run: |
-          sudo apt-get update
-          # shellcheck disable=SC2086
-          sudo apt-get install ${OS_DEPS}
+          case "${RUNNER_OS}" in
+            Linux)
+              sudo apt-get update
+              # shellcheck disable=SC2086
+              sudo apt-get install -y ${OS_DEPS}
+              ;;
+            macOS)
+              # shellcheck disable=SC2086
+              brew install ${OS_DEPS}
+              ;;
+            Windows)
+              # shellcheck disable=SC2086
+              choco install -y ${OS_DEPS}
+              ;;
+            *)
+              echo "unsupported RUNNER_OS=${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -95,6 +115,7 @@ jobs:
             ${{ secrets.SSH_PRIVATE_KEY }}
       -
         name: Build
+        shell: bash
         env:
           BUILD_CMD: ${{ inputs.build-command }}
         run: eval "${BUILD_CMD}"

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -54,8 +54,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.set-go-matrix.outputs.matrix) }}
     steps:
-      -
-        name: Install Dependencies # Some dependencies require this package
+      - name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
         shell: bash
         env:
@@ -80,29 +79,26 @@ jobs:
               exit 1
               ;;
           esac
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Reconfigure Git for go.step.sm
+      - name: Reconfigure Git for go.step.sm
         env:
           PAT: ${{ secrets.PAT }}
         if: ${{ env.PAT != '' }}
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
-      -
-        name: Install Go
+      - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
-      -
-        name: Setup SSH key for private dependencies
+          cache-dependency-path: '**/go.sum'
+      - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -110,8 +106,7 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Build
+      - name: Build
         shell: bash
         env:
           BUILD_CMD: ${{ inputs.build-command }}

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -28,24 +28,21 @@ on:
 
 jobs:
   set-go-matrix:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
     steps:
       - name: Set go-matrix latest version
         id: set-matrix-latest
         if: inputs.only-latest-golang
-        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""}]}' >> "${GITHUB_ENV}"
       - name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
-        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""},{"go":"\"oldstable\""}]}' >> "${GITHUB_ENV}"
       - id: set-output
-        shell: bash
         run: |
           echo "matrix=${{ env.matrix }}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
       build-command:
         required: false
         type: string
@@ -24,7 +28,7 @@ on:
 
 jobs:
   set-go-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
     steps:
@@ -44,7 +48,7 @@ jobs:
 
   build:
     needs: set-go-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     strategy:

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -59,6 +59,27 @@ on:
       os-dependencies:
         required: false
         type: string
+        default: ''
+      build-os-dependencies:
+        required: false
+        type: string
+        default: ''
+      codeql-os-dependencies:
+        required: false
+        type: string
+        default: ''
+      govulncheck-os-dependencies:
+        required: false
+        type: string
+        default: ''
+      lint-os-dependencies:
+        required: false
+        type: string
+        default: ''
+      test-os-dependencies:
+        required: false
+        type: string
+        default: ''
       run-actionlint:
         required: false
         type: boolean
@@ -121,7 +142,7 @@ jobs:
       goprivate: ${{ inputs.goprivate }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
       golangci-lint-args: ${{ inputs.golangci-lint-args }}
-      os-dependencies: ${{ inputs.os-dependencies }}
+      os-dependencies: ${{ inputs.lint-os-dependencies || inputs.os-dependencies || '' }}
       skip-go-generate: ${{ inputs.lint-skip-go-generate }}
       skip-go-mod-tidy: ${{ inputs.lint-skip-go-mod-tidy }}
     secrets:
@@ -133,7 +154,7 @@ jobs:
     if: inputs.run-govulncheck
     with:
       runs-on: ${{ inputs.govulncheck-runs-on || inputs.runs-on || 'ubuntu-latest' }}
-      os-dependencies: ${{ inputs.os-dependencies }}
+      os-dependencies: ${{ inputs.govulncheck-os-dependencies || inputs.os-dependencies || '' }}
       goprivate: ${{ inputs.goprivate }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -145,7 +166,7 @@ jobs:
     with:
       runs-on: ${{ inputs.codeql-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       goprivate: ${{ inputs.goprivate }}
-      os-dependencies: ${{ inputs.os-dependencies }}
+      os-dependencies: ${{ inputs.codeql-os-dependencies || inputs.os-dependencies || '' }}
       make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
       build-cmd: ${{ inputs.codeql-build-cmd }}
       build-mode: ${{ inputs.codeql-build-mode }}
@@ -160,7 +181,7 @@ jobs:
       runs-on: ${{ inputs.test-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       goprivate: ${{ inputs.goprivate }}
       only-latest-golang: ${{ inputs.only-latest-golang }}
-      os-dependencies: ${{ inputs.os-dependencies }}
+      os-dependencies: ${{ inputs.test-os-dependencies || inputs.os-dependencies || '' }}
       run-codecov: ${{ inputs.run-codecov }}
       setup-bats: ${{ inputs.setup-bats }}
       test-command: ${{ inputs.test-command }}
@@ -177,7 +198,7 @@ jobs:
       build-command: ${{ inputs.build-command }}
       goprivate: ${{ inputs.goprivate }}
       only-latest-golang: ${{ inputs.only-latest-golang }}
-      os-dependencies: ${{ inputs.os-dependencies }}
+      os-dependencies: ${{ inputs.build-os-dependencies || inputs.os-dependencies || '' }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PAT: ${{ secrets.PAT }}

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -16,10 +16,30 @@ on:
       codeql-make-bootstrap:
         required: false
         type: boolean
+      runs-on:
+        required: false
+        type: string
+        default: ''
+      build-runs-on:
+        required: false
+        type: string
+        default: ''
       codeql-runs-on:
         required: false
         type: string
-        default: ubuntu-latest
+        default: ''
+      govulncheck-runs-on:
+        required: false
+        type: string
+        default: ''
+      lint-runs-on:
+        required: false
+        type: string
+        default: ''
+      test-runs-on:
+        required: false
+        type: string
+        default: ''
       golangci-lint-version:
         required: false
         type: string
@@ -97,6 +117,7 @@ jobs:
     uses: ./.github/workflows/goLint.yml
     if: inputs.run-lint
     with:
+      runs-on: ${{ inputs.lint-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       goprivate: ${{ inputs.goprivate }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
       golangci-lint-args: ${{ inputs.golangci-lint-args }}
@@ -111,6 +132,7 @@ jobs:
     uses: ./.github/workflows/govulncheck.yml
     if: inputs.run-govulncheck
     with:
+      runs-on: ${{ inputs.govulncheck-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       os-dependencies: ${{ inputs.os-dependencies }}
       goprivate: ${{ inputs.goprivate }}
     secrets:
@@ -121,12 +143,12 @@ jobs:
     if: inputs.run-codeql
     uses: ./.github/workflows/codeql-analysis.yml
     with:
+      runs-on: ${{ inputs.codeql-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       goprivate: ${{ inputs.goprivate }}
       os-dependencies: ${{ inputs.os-dependencies }}
-      codeql-make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
-      codeql-build-cmd: ${{ inputs.codeql-build-cmd }}
-      codeql-build-mode: ${{ inputs.codeql-build-mode }}
-      codeql-runs-on: ${{ inputs.codeql-runs-on }}
+      make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
+      build-cmd: ${{ inputs.codeql-build-cmd }}
+      build-mode: ${{ inputs.codeql-build-mode }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PAT: ${{ secrets.PAT }}
@@ -135,6 +157,7 @@ jobs:
     uses: ./.github/workflows/goTest.yml
     if: inputs.run-test
     with:
+      runs-on: ${{ inputs.test-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       goprivate: ${{ inputs.goprivate }}
       only-latest-golang: ${{ inputs.only-latest-golang }}
       os-dependencies: ${{ inputs.os-dependencies }}
@@ -150,6 +173,7 @@ jobs:
     uses: ./.github/workflows/goBuild.yml
     if: inputs.run-build
     with:
+      runs-on: ${{ inputs.build-runs-on || inputs.runs-on || 'ubuntu-latest' }}
       build-command: ${{ inputs.build-command }}
       goprivate: ${{ inputs.goprivate }}
       only-latest-golang: ${{ inputs.only-latest-golang }}

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -43,12 +43,29 @@ jobs:
       -
         name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
+        shell: bash
         env:
           OS_DEPS: ${{ inputs.os-dependencies }}
         run: |
-          sudo apt-get update
-          # shellcheck disable=SC2086
-          sudo apt-get install ${OS_DEPS}
+          case "${RUNNER_OS}" in
+            Linux)
+              sudo apt-get update
+              # shellcheck disable=SC2086
+              sudo apt-get install -y ${OS_DEPS}
+              ;;
+            macOS)
+              # shellcheck disable=SC2086
+              brew install ${OS_DEPS}
+              ;;
+            Windows)
+              # shellcheck disable=SC2086
+              choco install -y ${OS_DEPS}
+              ;;
+            *)
+              echo "unsupported RUNNER_OS=${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,6 +115,7 @@ jobs:
       -
         name: Run go generate
         if: ( success() || failure() ) && !inputs.skip-go-generate
+        shell: bash
         run: |
           # delete all go-generated files (that adhere to the comment convention); protobuf code is excluded, because its output is (currently) not fully controlled by tools.go
           git ls-files -z | grep --include \*.go --exclude \*.pb.go -lrIZ "^// Code generated .* DO NOT EDIT\.$" | tr '\0' '\n' | xargs rm -f

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -78,6 +78,8 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: true
+          cache-dependency-path: '**/go.sum'
       -
         name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -118,7 +118,7 @@ jobs:
         shell: bash
         run: |
           # delete all go-generated files (that adhere to the comment convention); protobuf code is excluded, because its output is (currently) not fully controlled by tools.go
-          git ls-files -z | grep --include \*.go --exclude \*.pb.go -lrIZ "^// Code generated .* DO NOT EDIT\.$" | tr '\0' '\n' | xargs rm -f
+          git grep -l "^// Code generated .* DO NOT EDIT\.$" -- '*.go' ':!*.pb.go' | xargs rm -f
           # now generate everything
           go generate ./...
           # check if any files were changed

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -90,6 +90,7 @@ jobs:
       -
         name: Configure Linter
         if:  ${{ hashFiles('.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json') == '' }}
+        shell: bash
         run: |
           curl -O https://raw.githubusercontent.com/smallstep/workflows/main/.golangci.yml
       -

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
       os-dependencies:
         required: false
         type: string
@@ -32,7 +36,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     steps:

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -118,6 +118,7 @@ jobs:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
+          cache-dependency-path: '**/go.sum'
       -
         name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
       goprivate:
         required: false
         type: string
@@ -38,7 +42,7 @@ on:
 
 jobs:
   set-go-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
     steps:
@@ -61,7 +65,7 @@ jobs:
 
   test:
     needs: set-go-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     strategy:

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:
   set-go-matrix:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
     steps:
@@ -50,19 +50,16 @@ jobs:
         name: Set go-matrix latest version
         id: set-matrix-latest
         if: inputs.only-latest-golang
-        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""}]}' >> "${GITHUB_ENV}"
       -
         name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
-        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""},{"go":"\"oldstable\""}]}' >> "${GITHUB_ENV}"
       -
         id: set-output
-        shell: bash
         run: |
           echo "matrix=${{ env.matrix }}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -50,16 +50,19 @@ jobs:
         name: Set go-matrix latest version
         id: set-matrix-latest
         if: inputs.only-latest-golang
+        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""}]}' >> "${GITHUB_ENV}"
       -
         name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
+        shell: bash
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""},{"go":"\"oldstable\""}]}' >> "${GITHUB_ENV}"
       -
         id: set-output
+        shell: bash
         run: |
           echo "matrix=${{ env.matrix }}" >> "${GITHUB_OUTPUT}"
 
@@ -74,12 +77,29 @@ jobs:
       -
         name: Install Dependencies
         if: inputs.os-dependencies != ''
+        shell: bash
         env:
           OS_DEPS: ${{ inputs.os-dependencies }}
         run: |
-          sudo apt-get update
-          # shellcheck disable=SC2086
-          sudo apt-get install ${OS_DEPS}
+          case "${RUNNER_OS}" in
+            Linux)
+              sudo apt-get update
+              # shellcheck disable=SC2086
+              sudo apt-get install -y ${OS_DEPS}
+              ;;
+            macOS)
+              # shellcheck disable=SC2086
+              brew install ${OS_DEPS}
+              ;;
+            Windows)
+              # shellcheck disable=SC2086
+              choco install -y ${OS_DEPS}
+              ;;
+            *)
+              echo "unsupported RUNNER_OS=${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -88,37 +108,19 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       -
         name: Reconfigure for Git go.step.sm
+        if: env.PAT != ''
         env:
           PAT: ${{ secrets.PAT }}
-        if: env.PAT != ''
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
       -
         name: Setup Go
-        id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
-      -
-        name: chmod cache dir
-        if: steps.setup-go.outputs.cache-hit == 'true'
-        run: |
-          chmod -R 0755 \
-            ~/.cache/go-build \
-            ~/go/pkg/mod || true
-      -
-        name: Action Cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       -
         name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
@@ -130,10 +132,10 @@ jobs:
             ${{ secrets.SSH_PRIVATE_KEY }}
       -
         name: Install gotestsum
+        shell: bash
         env:
           GOTESTSUM_VERSION: ${{ inputs.gotestsum-version }}
-        run: |
-          go install "gotest.tools/gotestsum@v${GOTESTSUM_VERSION}"
+        run: go install "gotest.tools/gotestsum@v${GOTESTSUM_VERSION}"
       -
         name: Setup BATS
         if: inputs.setup-bats
@@ -142,6 +144,7 @@ jobs:
           bats-version: 1.9.0
       -
         name: Run Test Suite
+        shell: bash
         env:
           TEST_CMD: ${{ inputs.test-command }}
           GOTESTSUM_JSONFILE: gotestsum.json

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
       os-dependencies:
         required: false
         type: string
@@ -16,7 +20,7 @@ on:
 
 jobs:
   govulncheck:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     steps:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,12 +27,29 @@ jobs:
       -
         name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
+        shell: bash
         env:
           OS_DEPS: ${{ inputs.os-dependencies }}
         run: |
-          sudo apt-get update
-          # shellcheck disable=SC2086
-          sudo apt-get install ${OS_DEPS}
+          case "${RUNNER_OS}" in
+            Linux)
+              sudo apt-get update
+              # shellcheck disable=SC2086
+              sudo apt-get install -y ${OS_DEPS}
+              ;;
+            macOS)
+              # shellcheck disable=SC2086
+              brew install ${OS_DEPS}
+              ;;
+            Windows)
+              # shellcheck disable=SC2086
+              choco install -y ${OS_DEPS}
+              ;;
+            *)
+              echo "unsupported RUNNER_OS=${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -71,6 +71,7 @@ jobs:
           go-version: 'stable'
           check-latest: true
           cache: true
+          cache-dependency-path: '**/go.sum'
       -
         name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0


### PR DESCRIPTION
The reusable workflows in this repo were Linux-only by assumption: `runs-on` was hardcoded to `ubuntu-latest` in some places and derivable only from a single shared input in others, and the install step always shelled out to `apt-get`. That made it hard to point CI at the larger GitHub-hosted runners without piping a runner label through every leaf, and impossible to dispatch any of these workflows on non-Linux runners at all.

To that end, this PR threads `runs-on` through the parent workflows (`code-scan.yml`, `goCI.yml`) with a cascading default per child: the parent accepts a top-level `runs-on` plus per-child overrides (`lint-runs-on`, `test-runs-on`, `build-runs-on`, `govulncheck-runs-on`, `codeql-runs-on`), and each child resolves to `${{ inputs.<child>-runs-on || inputs.runs-on || 'ubuntu-latest' }}`. Each leaf (`goLint.yml`, `goTest.yml`, `goBuild.yml`, `govulncheck.yml`, `codeql-analysis.yml`) accepts its own plain `runs-on` input.

It also makes the leaves OS-aware where they used to be Linux-specific. The `Install Dependencies` step now dispatches on `${RUNNER_OS}` to call `apt-get` on Linux, `brew` on macOS, or `choco` on Windows; callers pass package names matching the runner they picked, since the workflow doesn't translate names. The redundant manual `actions/cache` + `chmod` steps in `goTest.yml` and `codeql-analysis.yml` were dropped — `actions/setup-go` with `cache: true` already handles per-OS cache paths. Steps that depend on POSIX shell features (`eval`, pipelines, `${GITHUB_ENV}` redirects) now declare `shell: bash` explicitly so they run under Git Bash on Windows runners.

In `codeql-analysis.yml`, the leaf inputs were also renamed to drop the redundant `codeql-` prefix (`build-cmd`, `build-mode`, `make-bootstrap`, `runs-on`); parent workflows still expose `codeql-*` inputs and map them down, so callers aren't affected. A grep across Smallstep repos confirmed nothing calls `codeql-analysis.yml` directly — every caller goes through `code-scan.yml` or `goCI.yml`.
