### PR TITLE
Add permissions block to codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,11 @@ on:
       PAT:
         required: false
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   codeql-analyze:
     name: CodeQL Analyze


### PR DESCRIPTION

`github/codeql-action` was bumped from v4.35.2 → v4.35.3 in 1fdd849 (2026-05-04). v4.35.3 calls `GET /repos/{owner}/{repo}/actions/runs/{run_id}` to compute the diff range for incremental analysis ("Generating diff range extension pack" in the logs). That call requires `actions: read` on the `GITHUB_TOKEN`.

`code-scan.yml` already declares the right permissions, but reusable-workflow permissions don't propagate to nested reusable workflows — each `workflow_call` file needs its own `permissions:` block, otherwise it falls back to the repo/org default token scopes. That's why scheduled scans started failing this week with:

```
Error: Resource not accessible by integration - https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run
```

Each scope is needed for:

- `actions: read` — read workflow-run metadata for diff-range / telemetry (the failing call).
- `contents: read` — `actions/checkout` and CodeQL `init` reading the source tree.
- `security-events: write` — `analyze` step uploading SARIF results to Code Scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)