### PR TITLE
Allow codeql analyze to read actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,9 @@ on:
       PAT:
         required: false
 
+permissions:
+  actions: read
+
 jobs:
   codeql-analyze:
     name: CodeQL Analyze


### PR DESCRIPTION
[Landlord is failing](https://github.com/smallstep/landlord/actions/runs/25511287969/job/74870436878?pr=576)  with `Error: Resource not accessible by integration - https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run`