### PR TITLE
Give CodeQL Analyze More Permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,8 @@ on:
 
 permissions:
   actions: read
+  contents: read
+  security-events: write
 
 jobs:
   codeql-analyze:


### PR DESCRIPTION
[Landlord is still failing](https://github.com/smallstep/landlord/actions/runs/25511287969/job/74882897780). Try giving codeql-analysis all the permissions code-scan has.