### PR TITLE
Revert unneeded permissions on codeql-analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,11 +31,6 @@ on:
       PAT:
         required: false
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-
 jobs:
   codeql-analyze:
     name: CodeQL Analyze


### PR DESCRIPTION
Landlord was fixed by adding `actions: read` to its ci permissions:

```yaml
  ci:
    permissions:
      contents: read
      actions: read
      security-events: write
```

Reverts #320 and #319 