### PR TITLE
Tighten the permissions of the reusable workflows we export

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,10 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
-indent_style = tab
 indent_size = 4
+indent_style = tab
+insert_final_newline = true
+tab_width = unset
 trim_trailing_whitespace = true
 
 [*.yml]

--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -32,8 +32,8 @@ jobs:
     if: inputs.run-frizbee
 
   # NOTE(@azazeal): callers that set run-zizmor: true (the default) must also
-  # grant security-events: write to the job that calls actionci.yml. Reusable
-  # workflows cannot be granted more than the caller has.
+  # grant actions: read and security-events: write to the job that calls
+  # actionci.yml. Reusable workflows cannot be granted more than the caller has.
   #
   # ref: https://docs.github.com/en/actions/reference/reusable-workflows-reference
   zizmor:
@@ -43,4 +43,5 @@ jobs:
       advanced-security: ${{ inputs.zizmor-advanced-security }}
     permissions:
       contents: read
+      actions: read
       security-events: write

--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -31,6 +31,11 @@ jobs:
     uses: ./.github/workflows/frizbee.yml
     if: inputs.run-frizbee
 
+  # NOTE(@azazeal): callers that set run-zizmor: true (the default) must also
+  # grant security-events: write to the job that calls actionci.yml. Reusable
+  # workflows cannot be granted more than the caller has.
+  #
+  # ref: https://docs.github.com/en/actions/reference/reusable-workflows-reference
   zizmor:
     uses: ./.github/workflows/zizmor.yml
     if: inputs.run-zizmor

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,9 @@ name: Lint GitHub Actions workflows
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     name: Lint GitHub workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/actionci.yml
     permissions:
       contents: read
+      actions: read
       security-events: write
 
   lint-dummy-app: # NOTE(@azazeal): this check is here to verify that .golangci.yml is valid

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,10 @@ on:
       PAT:
         required: false
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   codeql-analyze:
     name: CodeQL Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,18 +10,18 @@ on:
       build-cmd:
         required: false
         type: string
-        default: 'V=1 make build'
+        default: "V=1 make build"
       build-mode:
         required: false
         type: string
-        default: ''
+        default: ""
       make-bootstrap:
         required: false
         type: boolean
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
       os-dependencies:
         required: false
         type: string
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
     env:
@@ -81,10 +81,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable'
+          go-version: "stable"
           check-latest: true
           cache: true
-          cache-dependency-path: '**/go.sum'
+          cache-dependency-path: "**/go.sum"
       - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     permissions:
-      contents: write
-      pull-requests: write
+      pull-requests: read
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     permissions:
       id-token: write
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/frizbee.yml
+++ b/.github/workflows/frizbee.yml
@@ -3,6 +3,8 @@ name: Frizbee pinning check
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   frizbee:
     name: frizbee

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -26,6 +26,9 @@ on:
       PAT:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   set-go-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/goBuild.yml
+++ b/.github/workflows/goBuild.yml
@@ -8,7 +8,7 @@ on:
       build-command:
         required: false
         type: string
-        default: 'V=1 make build'
+        default: "V=1 make build"
       os-dependencies:
         required: false
         type: string
@@ -19,7 +19,7 @@ on:
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
     secrets:
       SSH_PRIVATE_KEY:
         required: false
@@ -100,7 +100,7 @@ jobs:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
-          cache-dependency-path: '**/go.sum'
+          cache-dependency-path: "**/go.sum"
       - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -4,42 +4,42 @@ on:
       build-command:
         required: false
         type: string
-        default: 'V=1 make build'
+        default: "V=1 make build"
       codeql-build-cmd:
         required: false
         type: string
-        default: 'V=1 make build'
+        default: "V=1 make build"
       codeql-build-mode:
         required: false
         type: string
-        default: ''
+        default: ""
       codeql-make-bootstrap:
         required: false
         type: boolean
       runs-on:
         required: false
         type: string
-        default: ''
+        default: ""
       build-runs-on:
         required: false
         type: string
-        default: ''
+        default: ""
       codeql-runs-on:
         required: false
         type: string
-        default: ''
+        default: ""
       govulncheck-runs-on:
         required: false
         type: string
-        default: ''
+        default: ""
       lint-runs-on:
         required: false
         type: string
-        default: ''
+        default: ""
       test-runs-on:
         required: false
         type: string
-        default: ''
+        default: ""
       golangci-lint-version:
         required: false
         type: string
@@ -47,7 +47,7 @@ on:
       golangci-lint-args:
         required: false
         type: string
-        default: '--timeout=30m'
+        default: "--timeout=30m"
       goprivate:
         required: false
         type: string
@@ -59,27 +59,27 @@ on:
       os-dependencies:
         required: false
         type: string
-        default: ''
+        default: ""
       build-os-dependencies:
         required: false
         type: string
-        default: ''
+        default: ""
       codeql-os-dependencies:
         required: false
         type: string
-        default: ''
+        default: ""
       govulncheck-os-dependencies:
         required: false
         type: string
-        default: ''
+        default: ""
       lint-os-dependencies:
         required: false
         type: string
-        default: ''
+        default: ""
       test-os-dependencies:
         required: false
         type: string
-        default: ''
+        default: ""
       run-actionlint:
         required: false
         type: boolean
@@ -115,7 +115,7 @@ on:
       test-command:
         required: false
         type: string
-        default: 'gotestsum -- -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...'
+        default: "gotestsum -- -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./..."
       lint-skip-go-generate:
         required: false
         type: boolean
@@ -133,7 +133,6 @@ on:
         required: false
 
 jobs:
-
   lint:
     uses: ./.github/workflows/goLint.yml
     if: inputs.run-lint
@@ -160,6 +159,11 @@ jobs:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PAT: ${{ secrets.PAT }}
 
+  # NOTE(@azazeal): callers that set run-codeql: true must also grant
+  # security-events: write to the job that calls goCI.yml. Reusable workflows
+  # cannot be granted more than the caller has.
+  #
+  # ref: https://docs.github.com/en/actions/reference/reusable-workflows-reference
   codeql:
     if: inputs.run-codeql
     uses: ./.github/workflows/codeql-analysis.yml
@@ -170,6 +174,9 @@ jobs:
       make-bootstrap: ${{ inputs.codeql-make-bootstrap }}
       build-cmd: ${{ inputs.codeql-build-cmd }}
       build-mode: ${{ inputs.codeql-build-mode }}
+    permissions:
+      contents: read
+      security-events: write
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PAT: ${{ secrets.PAT }}

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -51,7 +51,7 @@ on:
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
       only-latest-golang:
         required: false
         type: boolean

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -34,6 +34,9 @@ on:
       PAT:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/goLint.yml
+++ b/.github/workflows/goLint.yml
@@ -11,7 +11,7 @@ on:
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
       golangci-lint-version:
         required: false
         type: string
@@ -19,7 +19,7 @@ on:
       golangci-lint-args:
         required: false
         type: string
-        default: '--timeout=30m'
+        default: "--timeout=30m"
       skip-go-generate:
         required: false
         type: boolean
@@ -81,7 +81,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: true
-          cache-dependency-path: '**/go.sum'
+          cache-dependency-path: "**/go.sum"
 
       - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
@@ -122,7 +122,7 @@ jobs:
         if: success() || failure() # run this step even if the previous one failed
         with:
           version: ${{ inputs.golangci-lint-version }}
-          args: '${{ steps.configure-linter.outputs.extra-args }} ${{ inputs.golangci-lint-args }}'
+          args: "${{ steps.configure-linter.outputs.extra-args }} ${{ inputs.golangci-lint-args }}"
           verify: true
 
       - name: Run go generate

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -40,6 +40,9 @@ on:
       CODECOV_TOKEN:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   set-go-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -8,11 +8,11 @@ on:
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
       gotestsum-version:
         required: false
         type: string
-        default: '1.12.3'
+        default: "1.12.3"
       only-latest-golang:
         required: false
         type: boolean
@@ -31,7 +31,7 @@ on:
       test-command:
         required: false
         type: string
-        default: 'gotestsum -- -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...'
+        default: "gotestsum -- -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./..."
     secrets:
       SSH_PRIVATE_KEY:
         required: false
@@ -49,20 +49,17 @@ jobs:
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
     steps:
-      -
-        name: Set go-matrix latest version
+      - name: Set go-matrix latest version
         id: set-matrix-latest
         if: inputs.only-latest-golang
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""}]}' >> "${GITHUB_ENV}"
-      -
-        name: Set default go-matrix
+      - name: Set default go-matrix
         id: set-matrix-default
         if: inputs.only-latest-golang == false
         run: |
           echo 'matrix={"include":[{"go":"\"stable\""},{"go":"\"oldstable\""}]}' >> "${GITHUB_ENV}"
-      -
-        id: set-output
+      - id: set-output
         run: |
           echo "matrix=${{ env.matrix }}" >> "${GITHUB_OUTPUT}"
 
@@ -74,8 +71,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.set-go-matrix.outputs.matrix) }}
     steps:
-      -
-        name: Install Dependencies
+      - name: Install Dependencies
         if: inputs.os-dependencies != ''
         shell: bash
         env:
@@ -100,30 +96,26 @@ jobs:
               exit 1
               ;;
           esac
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Reconfigure for Git go.step.sm
+      - name: Reconfigure for Git go.step.sm
         if: env.PAT != ''
         env:
           PAT: ${{ secrets.PAT }}
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
-      -
-        name: Setup Go
+      - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: true
-          cache-dependency-path: '**/go.sum'
-      -
-        name: Setup SSH key for private dependencies
+          cache-dependency-path: "**/go.sum"
+      - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -131,34 +123,29 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Install gotestsum
+      - name: Install gotestsum
         shell: bash
         env:
           GOTESTSUM_VERSION: ${{ inputs.gotestsum-version }}
         run: go install "gotest.tools/gotestsum@v${GOTESTSUM_VERSION}"
-      -
-        name: Setup BATS
+      - name: Setup BATS
         if: inputs.setup-bats
         uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
         with:
           bats-version: 1.9.0
-      -
-        name: Run Test Suite
+      - name: Run Test Suite
         shell: bash
         env:
           TEST_CMD: ${{ inputs.test-command }}
           GOTESTSUM_JSONFILE: gotestsum.json
         run: eval "${TEST_CMD}"
 
-      -
-        name: Annotate Test Suite Results
+      - name: Annotate Test Suite Results
         if: ${{ (success() || failure()) && hashFiles('gotestsum.json') != '' }}
         uses: guyarb/golang-test-annotations@96fc379b171c49932041d6c789e73331a7bdeec1 # v0.9.0
         with:
           test-results: gotestsum.json
-      -
-        name: Codecov
+      - name: Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         if: inputs.run-codecov && matrix.go == 'stable'
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,7 +4,7 @@ on:
       cosign-version:
         required: false
         type: string
-        default: 'v2.6.2'
+        default: "v2.6.2"
       enable-packages-upload:
         required: false
         type: boolean
@@ -16,11 +16,11 @@ on:
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
       go-version:
         required: false
         type: string
-        default: 'stable'
+        default: "stable"
       is-prerelease:
         required: false
         type: boolean
@@ -31,7 +31,7 @@ on:
       runs-on:
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: "ubuntu-latest"
     secrets:
       SSH_PRIVATE_KEY:
         required: false
@@ -60,7 +60,6 @@ on:
       GOOGLE_CLOUD_PACKAGES_PROJECT_ID:
         required: false
 
-
 jobs:
   goreleaser:
     name: Upload Assets To Github w/ goreleaser
@@ -73,11 +72,9 @@ jobs:
       GOPRIVATE: ${{ inputs.goprivate }}
       GPG_PRIVATE_KEY_FILE: "0x889B19391F774443-Certify.key"
     steps:
-      -
-        name: Set IS_PRERELEASE
+      - name: Set IS_PRERELEASE
         run: echo "IS_PRERELEASE=${{ inputs.is-prerelease }}" >> "$GITHUB_ENV"
-      -
-        name: Install Dependencies # Some dependencies require this package
+      - name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
         env:
           OS_DEPS: ${{ inputs.os-dependencies }}
@@ -85,21 +82,17 @@ jobs:
           sudo apt-get update
           # shellcheck disable=SC2086
           sudo apt-get install ${OS_DEPS}
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      -
-        run: git fetch --force --tags
-      -
-        name: Set up Go
+      - run: git fetch --force --tags
+      - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '${{ inputs.go-version }}'
+          go-version: "${{ inputs.go-version }}"
           check-latest: true
-      -
-        name: Setup SSH key for private dependencies
+      - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -107,27 +100,23 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Reconfigure Git for private repos
+      - name: Reconfigure Git for private repos
         env:
           PAT: ${{ secrets.PAT }}
         if: ${{ env.PAT != '' }}
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
-      -
-        name: Install cosign
+      - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: '${{ inputs.cosign-version }}'
-      -
-        name: Get Release Date
+          cosign-release: "${{ inputs.cosign-version }}"
+      - name: Get Release Date
         id: release_date
         run: |
           RELEASE_DATE=$(date -u +"%y-%m-%d")
           echo "RELEASE_DATE=${RELEASE_DATE}" >> "${GITHUB_ENV}"
-      -
-        name: Authenticate to Google Cloud
+      - name: Authenticate to Google Cloud
         if: inputs.enable-packages-upload
         id: gcloud-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -135,22 +124,19 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_CLOUD_GITHUB_SERVICE_ACCOUNT }}
-      -
-        name: Set up Google Cloud SDK
+      - name: Set up Google Cloud SDK
         if: inputs.enable-packages-upload
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
         with:
           project_id: ${{ secrets.GOOGLE_CLOUD_PACKAGES_PROJECT_ID }}
-      -
-        name: Write GPG private key to file
+      - name: Write GPG private key to file
         if: inputs.enable-packages-upload || inputs.enable-gpg-sign
         run: |
           echo "${GPG_PRIVATE_KEY}" > "${GPG_PRIVATE_KEY_FILE}"
         shell: bash
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      -
-        name: Run GoReleaser Pro
+      - name: Run GoReleaser Pro
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           distribution: goreleaser-pro

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,7 +11,7 @@ on:
       goprivate:
         required: false
         type: string
-        default: go.step.sm,github.com/smallstep
+        default: go.step.sm/,github.com/smallstep/
     secrets:
       SSH_PRIVATE_KEY:
         required: false
@@ -27,8 +27,7 @@ jobs:
     env:
       GOPRIVATE: ${{ inputs.goprivate }}
     steps:
-      -
-        name: Install Dependencies # Some dependencies require this package
+      - name: Install Dependencies # Some dependencies require this package
         if: ${{ inputs.os-dependencies != '' }}
         shell: bash
         env:
@@ -53,30 +52,26 @@ jobs:
               exit 1
               ;;
           esac
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Reconfigure Git for go.step.sm
+      - name: Reconfigure Git for go.step.sm
         env:
           PAT: ${{ secrets.PAT }}
         if: ${{ env.PAT != '' }}
         run: |
           git config --global url.https://${{ secrets.PAT }}@github.com/.insteadOf git+ssh://git@github.com
           git config --global url.git@github.com:.insteadOf https://github.com/
-      -
-        name: Setup Go
+      - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable'
+          go-version: "stable"
           check-latest: true
           cache: true
-          cache-dependency-path: '**/go.sum'
-      -
-        name: Setup SSH key for private dependencies
+          cache-dependency-path: "**/go.sum"
+      - name: Setup SSH key for private dependencies
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -84,9 +79,7 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
-      -
-        name: Install govulncheck
+      - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
-      -
-        name: Run govulncheck
+      - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -18,6 +18,9 @@ on:
       PAT:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,9 +15,7 @@ on:
         type: boolean
         default: true
 
-permissions:
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   label-pr:
@@ -26,10 +24,9 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
     - name: Label PR
       run: |
         gh pr edit ${{ github.event.pull_request.number }} --add-label "needs triage"
@@ -38,6 +35,7 @@ jobs:
     name: Add to OSS Triage Project
     if: (inputs.run-add-to-oss-triage-project)
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,6 +7,11 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
 jobs:
   zizmor:
     name: zizmor


### PR DESCRIPTION
The reusable workflows under `.github/workflows/` had a mix of permission issues. Some declared no `permissions:` block at all (`actionlint.yml`, `frizbee.yml`, `goBuild.yml`, `goLint.yml`, `goTest.yml`, `govulncheck.yml`, `codeql-analysis.yml`, `zizmor.yml`), so callers had to remember what to grant. Others over-granted (`docker-buildx-push.yml` had `contents: write` it never used; `triage.yml` granted `pull-requests: write` and `issues: write` to both of its jobs when only one needed anything; `dependabot-auto-merge.yml` kept `contents: write` and `pull-requests: write` left over from before it switched to a PAT). And the implicit "caller must also grant X" contract on the umbrella workflows wasn't documented anywhere.

To that end, this PR pins explicit minimum permissions on every reusable workflow, fixes over-grants on `docker-buildx-push.yml`, `triage.yml`, and `dependabot-auto-merge.yml`, wires `security-events: write` through `goCI.yml`'s codeql call site, and adds `NOTE` comments documenting the caller-permission contract for the two cases where it can't be removed (`actionci.yml`'s zizmor child, `goCI.yml`'s codeql child).

The PR also includes a small unrelated `.editorconfig` tweak that respects the local tab-width setting.

Once this is merged, I'll make a pass over existing callers to amend accordingly.
