### PR TITLE
gh: granted actions: read through the codeql call chain

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   security-events: write
 
 jobs:

--- a/.github/workflows/goCI.yml
+++ b/.github/workflows/goCI.yml
@@ -160,8 +160,8 @@ jobs:
       PAT: ${{ secrets.PAT }}
 
   # NOTE(@azazeal): callers that set run-codeql: true must also grant
-  # security-events: write to the job that calls goCI.yml. Reusable workflows
-  # cannot be granted more than the caller has.
+  # actions: read and security-events: write to the job that calls goCI.yml.
+  # Reusable workflows cannot be granted more than the caller has.
   #
   # ref: https://docs.github.com/en/actions/reference/reusable-workflows-reference
   codeql:
@@ -176,6 +176,7 @@ jobs:
       build-mode: ${{ inputs.codeql-build-mode }}
     permissions:
       contents: read
+      actions: read
       security-events: write
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
The `github/codeql-action/analyze` action calls the `GET /actions/runs/{run_id}` API to fingerprint SARIF results before uploading. Without `actions: read` it falls back to a "configuration error" job status (observed in `smallstep/admin-tools` CI after merging smallstep/workflows#324). This PR closes the gap:

1. Adds `actions: read` to the workflow-level permissions in `codeql-analysis.yml` so the `codeql-analyze` job actually receives the scope.
2. Adds `actions: read` to the `codeql` job in `goCI.yml` so the scope isn't clipped away on the way down from the caller.
3. Updates the caller-contract `NOTE` in `goCI.yml` to mention `actions: read` alongside `security-events: write`.

Callers of `goCI.yml` with `run-codeql: true` (and callers of `code-scan.yml`) already grant `actions: read` on the calling job, so no caller-side changes are needed.
