### PR TITLE
gh: forwarded codeql secrets through code-scan.yml

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      PAT:
+        required: false
+      SSH_PRIVATE_KEY:
+        required: false
 
 permissions:
   actions: read
@@ -44,3 +49,6 @@ jobs:
       build-cmd: ${{ inputs.codeql-build-cmd }}
       build-mode: ${{ inputs.codeql-build-mode }}
       os-dependencies: ${{ inputs.codeql-os-dependencies || inputs.os-dependencies || '' }}
+    secrets:
+      PAT: ${{ secrets.PAT }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
`code-scan.yml` was failing for callers that depended on private repos as it didn't propagate the `SSH_PRIVATE_KEY` & `PAT` secrets.

This PR fixes that.