### PR TITLE
Fix triage labeling workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -28,8 +28,8 @@ jobs:
       issues: write
     steps:
     - name: Label PR
-      run: |
-        gh pr edit ${{ github.event.pull_request.number }} --add-label "needs triage"
+      run: | # plain GitHub API call replaces "gh pr edit"
+        gh api --method POST repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --field 'labels[]=needs triage'
 
   add-oss-project:
     name: Add to OSS Triage Project


### PR DESCRIPTION
The checkout was removed in https://github.com/smallstep/workflows/commit/6ec0ba4d1acc6fb6ca95a0f4c041a4e232b0c9a1. The checkout action is in fact used.